### PR TITLE
Add User Accounts

### DIFF
--- a/src/app/[username]/page.js
+++ b/src/app/[username]/page.js
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { Container, Typography, AppBar, Toolbar, Button } from "@mui/material";
 import LogoutIcon from "@mui/icons-material/Logout";
 import { useRouter, useParams } from "next/navigation";
@@ -7,6 +8,13 @@ import { useRouter, useParams } from "next/navigation";
 export default function UserPage() {
 	const { username } = useParams();
 	const router = useRouter();
+
+	useEffect(() => {
+		const token = localStorage.getItem("authToken");
+		if (!token) {
+			router.push("/");
+		}
+	}, []);
 
 	function handleLogout() {
 		localStorage.removeItem("authToken");

--- a/src/app/[username]/page.js
+++ b/src/app/[username]/page.js
@@ -1,0 +1,57 @@
+"use client";
+
+import { Container, Typography, AppBar, Toolbar, Button } from "@mui/material";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { useRouter, useParams } from "next/navigation";
+
+export default function UserPage() {
+	const { username } = useParams();
+	const router = useRouter();
+
+	function handleLogout() {
+		localStorage.removeItem("authToken");
+		router.push("/");
+	}
+
+	function goHome() {
+		router.push("/");
+	}
+
+	return (
+		<>
+			<AppBar position="static">
+				<Toolbar>
+					<Typography
+						variant="appName"
+						style={{
+							flexGrow: 1,
+							fontSize: "2rem",
+							cursor: "pointer",
+						}}
+						onClick={goHome}
+					>
+						Anthology
+					</Typography>
+					<Button
+						color="inherit"
+						startIcon={<LogoutIcon />}
+						onClick={handleLogout}
+					>
+						Logout
+					</Button>
+				</Toolbar>
+			</AppBar>
+			<Container
+				maxWidth="sm"
+				style={{ textAlign: "center", marginTop: "50px" }}
+			>
+				<Typography variant="heading" gutterBottom>
+					Welcome, {username}!
+				</Typography>
+				<Typography variant="h6" gutterBottom>
+					Nothing here yet.
+				</Typography>
+			</Container>
+		</>
+	);
+}

--- a/src/app/[username]/page.js
+++ b/src/app/[username]/page.js
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect } from "react";
-import { Container, Typography, AppBar, Toolbar, Button } from "@mui/material";
-import LogoutIcon from "@mui/icons-material/Logout";
 import { useRouter, useParams } from "next/navigation";
+import NavBar from "../components/NavBar";
+import { Container, Typography } from "@mui/material";
 
 export default function UserPage() {
 	const { username } = useParams();
@@ -16,39 +16,9 @@ export default function UserPage() {
 		}
 	}, []);
 
-	function handleLogout() {
-		localStorage.removeItem("authToken");
-		router.push("/");
-	}
-
-	function goHome() {
-		router.push("/");
-	}
-
 	return (
 		<>
-			<AppBar position="static">
-				<Toolbar>
-					<Typography
-						variant="appName"
-						style={{
-							flexGrow: 1,
-							fontSize: "2rem",
-							cursor: "pointer",
-						}}
-						onClick={goHome}
-					>
-						Anthology
-					</Typography>
-					<Button
-						color="inherit"
-						startIcon={<LogoutIcon />}
-						onClick={handleLogout}
-					>
-						Logout
-					</Button>
-				</Toolbar>
-			</AppBar>
+			<NavBar />
 			<Container
 				maxWidth="sm"
 				style={{ textAlign: "center", marginTop: "50px" }}

--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -3,13 +3,14 @@
 import { Container, Typography, AppBar, Toolbar, Button } from "@mui/material";
 import LogoutIcon from "@mui/icons-material/Logout";
 import { useRouter } from "next/navigation";
+import { getCookie, deleteCookie } from "../utils";
 
 export default function NavBar() {
-	const token = localStorage.getItem("authToken");
 	const router = useRouter();
 	const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 	async function handleLogout() {
+		const token = getCookie("authToken");
 		if (token) {
 			const response = await fetch(`${apiUrl}/logout/`, {
 				method: "POST",
@@ -17,7 +18,9 @@ export default function NavBar() {
 					Authorization: `Token ${token}`,
 				},
 			});
-			localStorage.removeItem("authToken");
+			if (response.ok) {
+				deleteCookie("authToken");
+			}
 		}
 		router.push("/");
 	}

--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -1,0 +1,41 @@
+"use client";
+
+import { Container, Typography, AppBar, Toolbar, Button } from "@mui/material";
+import LogoutIcon from "@mui/icons-material/Logout";
+import { useRouter } from "next/navigation";
+
+export default function NavBar() {
+	function handleLogout() {
+		localStorage.removeItem("authToken");
+		router.push("/");
+	}
+
+	function goHome() {
+		router.push("/");
+	}
+
+	return (
+		<AppBar position="static">
+			<Toolbar>
+				<Typography
+					variant="appName"
+					style={{
+						flexGrow: 1,
+						fontSize: "2rem",
+						cursor: "pointer",
+					}}
+					onClick={goHome}
+				>
+					Anthology
+				</Typography>
+				<Button
+					color="inherit"
+					startIcon={<LogoutIcon />}
+					onClick={handleLogout}
+				>
+					Logout
+				</Button>
+			</Toolbar>
+		</AppBar>
+	);
+}

--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -5,8 +5,20 @@ import LogoutIcon from "@mui/icons-material/Logout";
 import { useRouter } from "next/navigation";
 
 export default function NavBar() {
-	function handleLogout() {
-		localStorage.removeItem("authToken");
+	const token = localStorage.getItem("authToken");
+	const router = useRouter();
+	const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+
+	async function handleLogout() {
+		if (token) {
+			const response = await fetch(`${apiUrl}/logout/`, {
+				method: "POST",
+				headers: {
+					Authorization: `Token ${token}`,
+				},
+			});
+			localStorage.removeItem("authToken");
+		}
 		router.push("/");
 	}
 

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -1,20 +1,11 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import NavBar from "../components/NavBar";
 import { Container, Typography } from "@mui/material";
 
 export default function UserPage() {
-	const { username } = useParams();
 	const router = useRouter();
-
-	useEffect(() => {
-		const token = localStorage.getItem("authToken");
-		if (!token) {
-			router.push("/");
-		}
-	}, []);
 
 	return (
 		<>
@@ -24,7 +15,7 @@ export default function UserPage() {
 				style={{ textAlign: "center", marginTop: "50px" }}
 			>
 				<Typography variant="heading" gutterBottom>
-					Welcome, {username}!
+					Welcome!
 				</Typography>
 				<Typography variant="h6" gutterBottom>
 					Nothing here yet.

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -9,7 +9,7 @@ const appNameFont = Bricolage_Grotesque({
 });
 
 export default async function Home() {
-	const stories = await fetch("https://anthology.rcdis.co/stories/");
+	const stories = await fetch("http://localhost:8000/api/stories/");
 	const stories_data = await stories.json();
 
 	return (

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -9,7 +9,7 @@ const appNameFont = Bricolage_Grotesque({
 });
 
 export default async function Home() {
-	const stories = await fetch("http://localhost:8000/api/stories/");
+	const stories = await fetch("https://anthology.rcdis.co/api/stories/");
 	const stories_data = await stories.json();
 
 	return (

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -15,7 +15,7 @@ export default async function Home() {
 	return (
 		<>
 			<Grid container spacing={0}>
-				<Grid item size={{ sm: 12, md: 6 }}>
+				<Grid size={{ sm: 12, md: 6 }}>
 					<Box
 						sx={{
 							backgroundImage: "url('/blossom-background.png')",
@@ -61,7 +61,6 @@ export default async function Home() {
 					</Box>
 				</Grid>
 				<Grid
-					item
 					size={{ sm: 0, md: 6 }}
 					sx={{
 						backgroundColor: "#ecff3d",

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -9,7 +9,8 @@ const appNameFont = Bricolage_Grotesque({
 });
 
 export default async function Home() {
-	const stories = await fetch("https://anthology.rcdis.co/api/stories/");
+	const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+	const stories = await fetch(`${apiUrl}/stories/`);
 	const stories_data = await stories.json();
 
 	return (

--- a/src/app/sign-in/page.js
+++ b/src/app/sign-in/page.js
@@ -26,7 +26,7 @@ export default function SignIn() {
 		if (response.ok) {
 			const { username, token } = await response.json();
 			localStorage.setItem("authToken", token);
-			router.push(`/${username}`);
+			router.push("/dashboard");
 		} else {
 			console.error("Sign in failed");
 			// TODO display error message

--- a/src/app/sign-in/page.js
+++ b/src/app/sign-in/page.js
@@ -9,6 +9,7 @@ export default function SignIn() {
 	const [username, setUsername] = React.useState("");
 	const [password, setPassword] = React.useState("");
 	const router = useRouter();
+	const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 	async function handleSubmit(event) {
 		event.preventDefault();
@@ -17,7 +18,7 @@ export default function SignIn() {
 			username: username,
 			password: password,
 		};
-		const response = await fetch("https://anthology.rcdis.co/api/signin/", {
+		const response = await fetch(`${apiUrl}/signin/`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",

--- a/src/app/sign-in/page.js
+++ b/src/app/sign-in/page.js
@@ -2,7 +2,6 @@
 
 import React from "react";
 import { Container, TextField, Button, Typography, Box } from "@mui/material";
-import { getCsrfToken } from "../utils";
 import { useRouter } from "next/navigation";
 
 export default function SignIn() {
@@ -13,7 +12,6 @@ export default function SignIn() {
 
 	async function handleSubmit(event) {
 		event.preventDefault();
-		const csrfToken = getCsrfToken();
 		const user = {
 			username: username,
 			password: password,
@@ -22,7 +20,6 @@ export default function SignIn() {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"X-CSRFToken": csrfToken,
 			},
 			body: JSON.stringify(user),
 		});

--- a/src/app/sign-in/page.js
+++ b/src/app/sign-in/page.js
@@ -1,0 +1,61 @@
+"use client";
+
+import React from "react";
+import { Container, TextField, Button, Typography, Box } from "@mui/material";
+
+export default function SignIn() {
+	const handleSubmit = (event) => {
+		event.preventDefault();
+		// TODO submit form to backend
+		console.log("Sign In");
+	};
+
+	return (
+		<Container component="main" maxWidth="xs">
+			<Box
+				sx={{
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					marginTop: 8,
+				}}
+			>
+				<Typography component="h1" variant="appName">
+					Anthology
+				</Typography>
+				<Typography component="h1" variant="h4">
+					Sign In
+				</Typography>
+				<Box component="form" onSubmit={handleSubmit} sx={{ mt: 1 }}>
+					<TextField
+						margin="normal"
+						required
+						fullWidth
+						id="email"
+						label="Email Address"
+						name="email"
+						autoComplete="email"
+					/>
+					<TextField
+						margin="normal"
+						required
+						fullWidth
+						name="password"
+						label="Password"
+						type="password"
+						id="password"
+						autoComplete="current-password"
+					/>
+					<Button
+						type="submit"
+						fullWidth
+						variant="contained"
+						sx={{ mt: 3, mb: 2 }}
+					>
+						Sign In
+					</Button>
+				</Box>
+			</Box>
+		</Container>
+	);
+}

--- a/src/app/sign-in/page.js
+++ b/src/app/sign-in/page.js
@@ -25,7 +25,7 @@ export default function SignIn() {
 		});
 		if (response.ok) {
 			const { username, token } = await response.json();
-			localStorage.setItem("authToken", token);
+			document.cookie = `authToken=${token}; secure; SameSite=Strict; Path=/;`;
 			router.push("/dashboard");
 		} else {
 			console.error("Sign in failed");

--- a/src/app/sign-in/page.js
+++ b/src/app/sign-in/page.js
@@ -2,16 +2,38 @@
 
 import React from "react";
 import { Container, TextField, Button, Typography, Box } from "@mui/material";
+import { getCsrfToken } from "../utils";
+import { useRouter } from "next/navigation";
 
 export default function SignIn() {
 	const [username, setUsername] = React.useState("");
 	const [password, setPassword] = React.useState("");
+	const router = useRouter();
 
-	const handleSubmit = (event) => {
+	async function handleSubmit(event) {
 		event.preventDefault();
-		// TODO submit form to backend
-		console.log("Sign In");
-	};
+		const csrfToken = getCsrfToken();
+		const user = {
+			username: username,
+			password: password,
+		};
+		const response = await fetch("https://anthology.rcdis.co/api/signin/", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-CSRFToken": csrfToken,
+			},
+			body: JSON.stringify(user),
+		});
+		if (response.ok) {
+			const { username, token } = await response.json();
+			localStorage.setItem("authToken", token);
+			router.push(`/${username}`);
+		} else {
+			console.error("Sign in failed");
+			// TODO display error message
+		}
+	}
 
 	return (
 		<Container component="main" maxWidth="xs">
@@ -38,6 +60,7 @@ export default function SignIn() {
 						label="Username"
 						name="username"
 						value={username}
+						onChange={(e) => setUsername(e.target.value)}
 						autoComplete="username"
 						autoFocus
 					/>
@@ -50,6 +73,7 @@ export default function SignIn() {
 						type="password"
 						id="password"
 						value={password}
+						onChange={(e) => setPassword(e.target.value)}
 						autoComplete="current-password"
 					/>
 					<Button

--- a/src/app/sign-in/page.js
+++ b/src/app/sign-in/page.js
@@ -4,6 +4,9 @@ import React from "react";
 import { Container, TextField, Button, Typography, Box } from "@mui/material";
 
 export default function SignIn() {
+	const [username, setUsername] = React.useState("");
+	const [password, setPassword] = React.useState("");
+
 	const handleSubmit = (event) => {
 		event.preventDefault();
 		// TODO submit form to backend
@@ -31,10 +34,12 @@ export default function SignIn() {
 						margin="normal"
 						required
 						fullWidth
-						id="email"
-						label="Email Address"
-						name="email"
-						autoComplete="email"
+						id="username"
+						label="Username"
+						name="username"
+						value={username}
+						autoComplete="username"
+						autoFocus
 					/>
 					<TextField
 						margin="normal"
@@ -44,6 +49,7 @@ export default function SignIn() {
 						label="Password"
 						type="password"
 						id="password"
+						value={password}
 						autoComplete="current-password"
 					/>
 					<Button

--- a/src/app/sign-up/page.js
+++ b/src/app/sign-up/page.js
@@ -1,0 +1,71 @@
+"use client";
+
+import React from "react";
+import { Container, TextField, Button, Typography, Box } from "@mui/material";
+
+export default function SignUp() {
+	const handleSubmit = (event) => {
+		event.preventDefault();
+		// TODO submit form to backend
+		console.log("Sign Up");
+	};
+
+	return (
+		<Container component="main" maxWidth="xs">
+			<Box
+				sx={{
+					display: "flex",
+					flexDirection: "column",
+					alignItems: "center",
+					marginTop: 8,
+				}}
+			>
+				<Typography component="h1" variant="appName">
+					Anthology
+				</Typography>
+				<Typography component="h1" variant="h4">
+					Sign Up
+				</Typography>
+				<Box component="form" onSubmit={handleSubmit} sx={{ mt: 1 }}>
+					<TextField
+						margin="normal"
+						required
+						fullWidth
+						id="username"
+						label="Username"
+						name="username"
+						autoComplete="username"
+						autoFocus
+					/>
+					<TextField
+						margin="normal"
+						required
+						fullWidth
+						id="email"
+						label="Email Address"
+						name="email"
+						autoComplete="email"
+					/>
+					<TextField
+						margin="normal"
+						required
+						fullWidth
+						name="password"
+						label="Password"
+						type="password"
+						id="password"
+						autoComplete="current-password"
+					/>
+					<Button
+						type="submit"
+						fullWidth
+						variant="contained"
+						sx={{ mt: 3, mb: 2 }}
+					>
+						Sign Up
+					</Button>
+				</Box>
+			</Box>
+		</Container>
+	);
+}

--- a/src/app/sign-up/page.js
+++ b/src/app/sign-up/page.js
@@ -28,7 +28,7 @@ export default function SignUp() {
 		if (response.ok) {
 			const { username, token } = await response.json();
 			localStorage.setItem("authToken", token);
-			router.push(`/${username}`);
+			router.push("/dashboard");
 		} else {
 			console.error("Sign up failed");
 			// TODO display error message

--- a/src/app/sign-up/page.js
+++ b/src/app/sign-up/page.js
@@ -2,13 +2,39 @@
 
 import React from "react";
 import { Container, TextField, Button, Typography, Box } from "@mui/material";
+import { getCsrfToken } from "../utils";
+import { useRouter } from "next/navigation";
 
 export default function SignUp() {
-	const handleSubmit = (event) => {
+	const [username, setUsername] = React.useState("");
+	const [email, setEmail] = React.useState("");
+	const [password, setPassword] = React.useState("");
+	const router = useRouter();
+
+	async function handleSubmit(event) {
 		event.preventDefault();
-		// TODO submit form to backend
-		console.log("Sign Up");
-	};
+		const csrfToken = getCsrfToken();
+		const user = {
+			username: username,
+			email: email,
+			password: password,
+		};
+		const response = await fetch("https://anthology.rcdis.co/api/signup/", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"X-CSRFToken": csrfToken,
+			},
+			body: JSON.stringify(user),
+		});
+		if (response.ok) {
+			const newUser = response.json();
+			router.push(`/${newUser.username}`);
+		} else {
+			console.log("Sign up failed");
+			// TODO display error message
+		}
+	}
 
 	return (
 		<Container component="main" maxWidth="xs">
@@ -34,6 +60,8 @@ export default function SignUp() {
 						id="username"
 						label="Username"
 						name="username"
+						value={username}
+						onChange={(e) => setUsername(e.target.value)}
 						autoComplete="username"
 						autoFocus
 					/>
@@ -44,6 +72,8 @@ export default function SignUp() {
 						id="email"
 						label="Email Address"
 						name="email"
+						value={email}
+						onChange={(e) => setEmail(e.target.value)}
 						autoComplete="email"
 					/>
 					<TextField
@@ -54,6 +84,8 @@ export default function SignUp() {
 						label="Password"
 						type="password"
 						id="password"
+						value={password}
+						onChange={(e) => setPassword(e.target.value)}
 						autoComplete="current-password"
 					/>
 					<Button

--- a/src/app/sign-up/page.js
+++ b/src/app/sign-up/page.js
@@ -27,7 +27,7 @@ export default function SignUp() {
 		});
 		if (response.ok) {
 			const { username, token } = await response.json();
-			localStorage.setItem("authToken", token);
+			document.cookie = `authToken=${token}; secure; SameSite=Strict; Path=/;`;
 			router.push("/dashboard");
 		} else {
 			console.error("Sign up failed");

--- a/src/app/sign-up/page.js
+++ b/src/app/sign-up/page.js
@@ -2,7 +2,6 @@
 
 import React from "react";
 import { Container, TextField, Button, Typography, Box } from "@mui/material";
-import { getCsrfToken } from "../utils";
 import { useRouter } from "next/navigation";
 
 export default function SignUp() {
@@ -14,7 +13,6 @@ export default function SignUp() {
 
 	async function handleSubmit(event) {
 		event.preventDefault();
-		const csrfToken = getCsrfToken();
 		const user = {
 			username: username,
 			email: email,
@@ -24,7 +22,6 @@ export default function SignUp() {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"X-CSRFToken": csrfToken,
 			},
 			body: JSON.stringify(user),
 		});

--- a/src/app/sign-up/page.js
+++ b/src/app/sign-up/page.js
@@ -10,6 +10,7 @@ export default function SignUp() {
 	const [email, setEmail] = React.useState("");
 	const [password, setPassword] = React.useState("");
 	const router = useRouter();
+	const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 	async function handleSubmit(event) {
 		event.preventDefault();
@@ -19,7 +20,7 @@ export default function SignUp() {
 			email: email,
 			password: password,
 		};
-		const response = await fetch("https://anthology.rcdis.co/api/signup/", {
+		const response = await fetch(`${apiUrl}/signup/`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",

--- a/src/app/sign-up/page.js
+++ b/src/app/sign-up/page.js
@@ -28,10 +28,11 @@ export default function SignUp() {
 			body: JSON.stringify(user),
 		});
 		if (response.ok) {
-			const newUser = response.json();
-			router.push(`/${newUser.username}`);
+			const { username, token } = await response.json();
+			localStorage.setItem("authToken", token);
+			router.push(`/${username}`);
 		} else {
-			console.log("Sign up failed");
+			console.error("Sign up failed");
 			// TODO display error message
 		}
 	}

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -1,6 +1,0 @@
-export const getCsrfToken = () => {
-	const name = "csrftoken";
-	const value = `; ${document.cookie}`;
-	const parts = value.split(`; ${name}=`);
-	if (parts.length === 2) return parts.pop().split(";").shift();
-};

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -1,0 +1,6 @@
+export const getCsrfToken = () => {
+	const name = "csrftoken";
+	const value = `; ${document.cookie}`;
+	const parts = value.split(`; ${name}=`);
+	if (parts.length === 2) return parts.pop().split(";").shift();
+};

--- a/src/app/utils.js
+++ b/src/app/utils.js
@@ -1,0 +1,9 @@
+export const getCookie = (name) => {
+	const value = `; ${document.cookie}`;
+	const parts = value.split(`; ${name}=`);
+	if (parts.length === 2) return parts.pop().split(";").shift();
+};
+export const deleteCookie = (name) => {
+	document.cookie =
+		name + "=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;";
+};

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+
+const protectedRoutes = ["/dashboard"];
+
+export default async function middleware(request) {
+	const path = request.nextUrl.pathname;
+	const token = (await cookies()).get("authToken")?.value;
+
+	if (protectedRoutes.includes(path) && !token) {
+		return NextResponse.redirect(new URL("/sign-in", request.nextUrl));
+	}
+
+	return NextResponse.next();
+}
+
+// Routes Middleware should not run on
+export const config = {
+	matcher: ["/((?!_next/static|_next/image|.*\\.png$).*)"],
+};


### PR DESCRIPTION
Note: The [corresponding backend PR](https://github.com/klee97/anthology-app-backend/pull/1) must be merged and deployed first for this deployment to be successful.
- Created sign-up and sign-in pages.
- Implemented a dashboard route for the user home. Initially, this was a dynamic [username] route, but to simplify user authentication checks, I opted for a static route for now.
- Added middleware to protect the dashboard route. I attempted to use useEffect for redirecting to the login page if the user signed out, but encountered a flash of the dashboard page before the redirect.
- Auth token is stored in cookies for access by middleware.
- A small quality-of-life improvement:  added a .env file for local development and set environment variables on Vercel, so we don’t have to switch the backend URL between development and production.

Future Plans:
- Explore the implementation of a custom authentication class on the backend that can read the token from cookies instead of the Authorization header. This change would allow us to set the cookie as httpOnly, which is better for security.